### PR TITLE
Add xDai & Polygon chainIds to WalletConnect connector

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -24,7 +24,8 @@ export const injected = new InjectedConnector({
 // mainnet only
 export const walletConnect = new WalletConnectConnector({
   rpc: {
-    1: `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`
+    100: 'https://rpc.xdaichain.com/',
+    137: 'https://rpc-mainnet.matic.quiknode.pro'
   },
   bridge: 'https://bridge.walletconnect.org',
   qrcode: true,


### PR DESCRIPTION
There is a concerning issue connecting to the Honeyswap via WalletConnect. It seems that it is not possible to connect to the website neither on xDai nor Polygon Network. The chainId on onSessionRequest is 1, which is confusing when integrating it with a wallet that I am currently implementing. Moreover, despite the requested chainId, Ethereum is always requested.

This PR solves this issue by adding the xDai & Polygon chainIds and their respective RPCs.