### PR TITLE
fix: show correct protocol fee for xDai LPs

### DIFF
--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -104,7 +104,7 @@ export default function AddLiquidity({
     [dependentField]: noLiquidity ? otherTypedValue : parsedAmounts[dependentField]?.toSignificant(6) ?? ''
   }
 
-  const { protocolFee } = calculateProtocolFee(pair, parsedAmounts[independentField])
+  const { protocolFee } = calculateProtocolFee(pair, parsedAmounts[independentField], chainId)
   const swapFee = pair ? new Percent(JSBI.BigInt(pair.swapFee.toString()), JSBI.BigInt(10000)) : undefined
 
   // get the max amounts user can add

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -64,7 +64,14 @@ export function calculateProtocolFee(
   amount?: CurrencyAmount,
   chainId?: number
 ): { protocolFee?: Fraction; protocolFeeAmount?: CurrencyAmount } {
-  const protocolFee = pair ? new Percent(pair.swapFee, _100).divide(pair.protocolFeeDenominator) : undefined
+  let protocolFee
+
+  // xDai has a fixed protocol fee of 0.05%
+  if (chainId === 100) {
+    protocolFee = pair ? new Percent('5', _10000) : undefined
+  } else if (chainId === 137) {
+    protocolFee = pair ? new Percent(pair.swapFee, _100).divide(pair.protocolFeeDenominator) : undefined
+  }
 
   // the amount of the input that accrues to LPs
   const protocolFeeAmount =


### PR DESCRIPTION
xDai has a fixed protocol fee, unlike Polygon contracts. This PR fixes it.