### PR TITLE
fix: use WalletConnect connector dynamically

### DIFF
--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -196,7 +196,6 @@ export default function WalletModal({
     } else if (chainId === ChainId.XDAI) {
       SUPPORTED_WALLETS['WALLET_CONNECT'].connector = walletConnectXDAI
     }
-    console.log(SUPPORTED_WALLETS['WALLET_CONNECT'].connector)
     return Object.keys(SUPPORTED_WALLETS).map(key => {
       const option = SUPPORTED_WALLETS[key]
       // check for mobile options

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -14,11 +14,13 @@ import { ApplicationModal } from '../../state/application/actions'
 import { useModalOpen, useWalletModalToggle } from '../../state/application/hooks'
 import { TYPE } from '../../theme'
 import AccountDetails from '../AccountDetails'
+import { walletConnectXDAI, walletConnectMATIC } from '../../connectors'
 
 import Modal from '../Modal'
 import Option from './Option'
 import PendingView from './PendingView'
 import BeeLogo from '../../assets/svg/logo.svg'
+import { ChainId } from 'dxswap-sdk'
 
 const CloseIcon = styled.div`
   position: absolute;
@@ -131,8 +133,7 @@ export default function WalletModal({
   ENSName?: string
 }) {
   // important that these are destructed from the account-specific web3-react context
-  const { active, account, connector, activate, error } = useWeb3React()
-
+  const { chainId, active, account, connector, activate, error } = useWeb3React()
   const [walletView, setWalletView] = useState(WALLET_VIEWS.ACCOUNT)
 
   const [pendingWallet, setPendingWallet] = useState<AbstractConnector | undefined>()
@@ -190,6 +191,13 @@ export default function WalletModal({
   // get wallets user can switch too, depending on device/browser
   function getOptions() {
     const isMetamask = window.ethereum && window.ethereum.isMetaMask
+    if (chainId === ChainId.MATIC) {
+      SUPPORTED_WALLETS['WALLET_CONNECT'].connector = walletConnectMATIC
+    } else if (chainId === ChainId.XDAI) {
+      SUPPORTED_WALLETS['WALLET_CONNECT'].connector = walletConnectXDAI
+    } else {
+      delete SUPPORTED_WALLETS['WALLET_CONNECT']
+    }
     return Object.keys(SUPPORTED_WALLETS).map(key => {
       const option = SUPPORTED_WALLETS[key]
       // check for mobile options

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -14,13 +14,11 @@ import { ApplicationModal } from '../../state/application/actions'
 import { useModalOpen, useWalletModalToggle } from '../../state/application/hooks'
 import { TYPE } from '../../theme'
 import AccountDetails from '../AccountDetails'
-import { walletConnectXDAI, walletConnectMATIC } from '../../connectors'
 
 import Modal from '../Modal'
 import Option from './Option'
 import PendingView from './PendingView'
 import BeeLogo from '../../assets/svg/logo.svg'
-import { ChainId } from 'dxswap-sdk'
 
 const CloseIcon = styled.div`
   position: absolute;
@@ -133,7 +131,7 @@ export default function WalletModal({
   ENSName?: string
 }) {
   // important that these are destructed from the account-specific web3-react context
-  const { chainId, active, account, connector, activate, error } = useWeb3React()
+  const { active, account, connector, activate, error } = useWeb3React()
   const [walletView, setWalletView] = useState(WALLET_VIEWS.ACCOUNT)
 
   const [pendingWallet, setPendingWallet] = useState<AbstractConnector | undefined>()
@@ -191,11 +189,7 @@ export default function WalletModal({
   // get wallets user can switch too, depending on device/browser
   function getOptions() {
     const isMetamask = window.ethereum && window.ethereum.isMetaMask
-    if (chainId === ChainId.MATIC) {
-      SUPPORTED_WALLETS['WALLET_CONNECT'].connector = walletConnectMATIC
-    } else if (chainId === ChainId.XDAI) {
-      SUPPORTED_WALLETS['WALLET_CONNECT'].connector = walletConnectXDAI
-    }
+
     return Object.keys(SUPPORTED_WALLETS).map(key => {
       const option = SUPPORTED_WALLETS[key]
       // check for mobile options

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -195,9 +195,8 @@ export default function WalletModal({
       SUPPORTED_WALLETS['WALLET_CONNECT'].connector = walletConnectMATIC
     } else if (chainId === ChainId.XDAI) {
       SUPPORTED_WALLETS['WALLET_CONNECT'].connector = walletConnectXDAI
-    } else {
-      delete SUPPORTED_WALLETS['WALLET_CONNECT']
     }
+    console.log(SUPPORTED_WALLETS['WALLET_CONNECT'].connector)
     return Object.keys(SUPPORTED_WALLETS).map(key => {
       const option = SUPPORTED_WALLETS[key]
       // check for mobile options

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -21,10 +21,19 @@ export const injected = new InjectedConnector({
   supportedChainIds: [ChainId.RINKEBY, ChainId.SOKOL, ChainId.XDAI, ChainId.MATIC]
 })
 
-// mainnet only
-export const walletConnect = new WalletConnectConnector({
+// xdai only
+export const walletConnectXDAI = new WalletConnectConnector({
   rpc: {
-    100: 'https://rpc.xdaichain.com/',
+    100: 'https://rpc.xdaichain.com/'
+  },
+  bridge: 'https://bridge.walletconnect.org',
+  qrcode: true,
+  pollingInterval: 15000
+})
+
+// polygon only
+export const walletConnectMATIC = new WalletConnectConnector({
+  rpc: {
     137: 'https://rpc-mainnet.matic.quiknode.pro'
   },
   bridge: 'https://bridge.walletconnect.org',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,7 +1,7 @@
 import { AbstractConnector } from '@web3-react/abstract-connector'
 import { ChainId, JSBI, Percent, CurrencyAmount, WETH, WSPOA, WXDAI, Token, Currency, WMATIC } from 'dxswap-sdk'
 import { tokens } from './tokens'
-import { authereum, injected, walletConnect } from '../connectors'
+import { injected, walletConnectXDAI } from '../connectors'
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
@@ -185,19 +185,10 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
     color: '#E8831D'
   },
   WALLET_CONNECT: {
-    connector: walletConnect,
+    connector: walletConnectXDAI, // defaults to xDai
     name: 'WalletConnect',
     iconName: 'wallet-connect.svg',
     description: 'Connect to Trust Wallet, Rainbow Wallet and more...',
-    href: null,
-    color: '#4196FC',
-    mobile: true
-  },
-  AUTHEREUM: {
-    connector: authereum,
-    name: 'Authereum',
-    iconName: 'authereum.svg',
-    description: 'Connect using Authereum.',
     href: null,
     color: '#4196FC',
     mobile: true

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,7 +1,7 @@
 import { AbstractConnector } from '@web3-react/abstract-connector'
 import { ChainId, JSBI, Percent, CurrencyAmount, WETH, WSPOA, WXDAI, Token, Currency, WMATIC } from 'dxswap-sdk'
 import { tokens } from './tokens'
-import { injected, walletConnectXDAI } from '../connectors'
+import { injected, walletConnectMATIC, walletConnectXDAI } from '../connectors'
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
@@ -184,9 +184,18 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
     href: null,
     color: '#E8831D'
   },
-  WALLET_CONNECT: {
-    connector: walletConnectXDAI, // defaults to xDai
-    name: 'WalletConnect',
+  WALLET_CONNECT_XDAI: {
+    connector: walletConnectXDAI,
+    name: 'WalletConnect for xDai',
+    iconName: 'wallet-connect.svg',
+    description: 'Connect to Trust Wallet, Rainbow Wallet and more...',
+    href: null,
+    color: '#4196FC',
+    mobile: true
+  },
+  WALLET_CONNECT_MATIC: {
+    connector: walletConnectMATIC,
+    name: 'WalletConnect for Polygon',
     iconName: 'wallet-connect.svg',
     description: 'Connect to Trust Wallet, Rainbow Wallet and more...',
     href: null,


### PR DESCRIPTION
We were using a single connector to attempt to connect to both Polygon & xDai, it seems that we need a connector for each network and picks the correct one when needed.

This PR includes one WalletConnect options for each network.