### PR TITLE
change walletconnect bridge for polygon

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -36,7 +36,7 @@ export const walletConnectMATIC = new WalletConnectConnector({
   rpc: {
     137: 'https://rpc-mainnet.matic.quiknode.pro'
   },
-  bridge: 'https://bridge.walletconnect.org',
+  bridge: 'https://polygon.bridge.walletconnect.org',
   qrcode: true,
   pollingInterval: 15000
 })


### PR DESCRIPTION
Other bridge has capacity issues, the new one is dedicated for polygon.

Still would be better to run your own bridge (aka. relay) https://github.com/WalletConnect/walletconnect-monorepo/tree/v2.0/servers/relay