### PR TITLE
Configure minerva walletconnect relay for xdai #64

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -31,7 +31,7 @@ export const walletConnectXDAI = new WalletConnectConnector({
   rpc: {
     100: 'https://poa-xdai.gateway.pokt.network/v1/lb/61140fc659501900341babff'
   },
-  bridge: 'https://bridge.walletconnect.org',
+  bridge: 'https://walletconnect-relay.minerva.digital',
   qrcode: true,
   pollingInterval: 15000
 })


### PR DESCRIPTION
see: #64 

The bridge (relay) is run by https://minerva.digital .
Feel free to donate some HNY to 0x6A0491132aF4d0925F857A5000bb21e5C5C195EA on xdai chain for running that bridge.