### PR TITLE
Remove hny from routing

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -150,7 +150,7 @@ export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
     USDC[ChainId.XDAI],
     USDT[ChainId.XDAI],
     WBTC[ChainId.XDAI],
-    HONEY[ChainId.XDAI],
+    // HONEY[ChainId.XDAI],
     AGAVE,
     GIV,
     TEC,


### PR DESCRIPTION
Until the next vote to upgrade the token manager passes we need to remove it from routing.
https://forum.1hive.org/t/i-accidentally-messed-up-with-hny-transferability/5277